### PR TITLE
Add main manager and role attributes to company and employee models

### DIFF
--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -1,12 +1,13 @@
 class EmployeesController < ApplicationController
+  before_action :set_company
+  before_action :set_employee, only: [:destroy, :set_manager]
+
   def index
-    company = Company.find(params[:company_id])
-    render json: company.employees
+    render json: @company.employees
   end
 
-   def create
-    company = Company.find(params[:company_id])
-    employee = company.employees.build(employee_params)
+  def create
+    employee = @company.employees.build(employee_params)
 
     if employee.save
       render json: employee, status: :created
@@ -16,14 +17,32 @@ class EmployeesController < ApplicationController
   end
 
   def destroy
-    company = Company.find(params[:company_id])
-    employee = company.employees.find(params[:id])
-    employee.destroy
+    @employee.destroy
     head :no_content
   end
 
+  def set_manager
+    manager = @company.employees.find(params[:manager_id])
+    @employee.manager = manager
+
+    if @employee.save
+      render json: @employee, status: :ok
+    else
+      render json: { errors: @employee.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
   private
+
+  def set_company
+    @company = Company.find(params[:company_id])
+  end
+
+  def set_employee
+    @employee = @company.employees.find(params[:id])
+  end
+
   def employee_params
-    params.require(:employee).permit(:name, :email, :picture)
+      params.require(:employee).permit(:name, :email, :picture, :manager_id, :admin, :superadmin)
   end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,5 +1,7 @@
 class Company < ApplicationRecord
   has_many :employees, dependent: :destroy
 
+  belongs_to :main_manager, class_name: "Employee", optional: true
+
   validates :name, presence: true
 end

--- a/db/migrate/20250726185143_add_main_manager_to_companies.rb
+++ b/db/migrate/20250726185143_add_main_manager_to_companies.rb
@@ -1,0 +1,7 @@
+class AddMainManagerToCompanies < ActiveRecord::Migration[7.1]
+  def change
+    add_column :companies, :main_manager_id, :bigint
+    add_foreign_key :companies, :employees, column: :main_manager_id
+    add_index :companies, :main_manager_id
+  end
+end

--- a/db/migrate/20250726191428_add_admin_to_employees.rb
+++ b/db/migrate/20250726191428_add_admin_to_employees.rb
@@ -1,0 +1,5 @@
+class AddAdminToEmployees < ActiveRecord::Migration[7.1]
+  def change
+    add_column :employees, :admin, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20250726191734_add_superadmin_to_employees.rb
+++ b/db/migrate/20250726191734_add_superadmin_to_employees.rb
@@ -1,0 +1,5 @@
+class AddSuperadminToEmployees < ActiveRecord::Migration[7.1]
+  def change
+    add_column :employees, :superadmin, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_22_201311) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_26_191734) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,6 +18,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_22_201311) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "main_manager_id"
+    t.index ["main_manager_id"], name: "index_companies_on_main_manager_id"
   end
 
   create_table "employees", force: :cascade do |t|
@@ -28,10 +30,13 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_22_201311) do
     t.bigint "manager_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "admin", default: false, null: false
+    t.boolean "superadmin", default: false, null: false
     t.index ["company_id"], name: "index_employees_on_company_id"
     t.index ["manager_id"], name: "index_employees_on_manager_id"
   end
 
+  add_foreign_key "companies", "employees", column: "main_manager_id"
   add_foreign_key "employees", "companies"
   add_foreign_key "employees", "employees", column: "manager_id"
 end


### PR DESCRIPTION
- Implemented main_manager association in Company model.
- Added admin and superadmin boolean fields to Employee model.
- Updated EmployeesController to utilize instance variables for company and employee.
- Enhanced employee_params to permit new attributes.
- Created migrations for adding main_manager_id, admin, and superadmin fields.